### PR TITLE
Permit uppercase characters in UUID

### DIFF
--- a/openapi_schema_validator/_format.py
+++ b/openapi_schema_validator/_format.py
@@ -90,7 +90,7 @@ def is_uuid(instance):
     if isinstance(instance, binary_type):
         instance = instance.decode()
 
-    return text_type(UUID(instance)) == instance
+    return text_type(UUID(instance)).lower() == instance.lower()
 
 
 def is_password(instance):


### PR DESCRIPTION
This seems to match RFC 4122

>  Each field is treated as an integer and has its value printed as a zero-filled hexadecimal digit string with the most significant digit first.  The hexadecimal values "a" through "f" are output as lower case characters and are case insensitive on input.