### PR TITLE
Fix mock import in Python 3.x

### DIFF
--- a/tests/integration/test_validators.py
+++ b/tests/integration/test_validators.py
@@ -1,9 +1,13 @@
 from jsonschema import ValidationError
-import mock
 import pytest
 from six import u
 
 from openapi_schema_validator import OAS30Validator, oas30_format_checker
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 
 class TestOAS30ValidatorValidate(object):


### PR DESCRIPTION
`mock` is not installed on Python 3.x according to setup.cfg: `mock; python_version<"3.0"`. Import it from stdlib to fix the ImportError.