### PR TITLE
Use official OSI name in the license metadata

### DIFF
--- a/openapi_schema_validator/__init__.py
+++ b/openapi_schema_validator/__init__.py
@@ -7,6 +7,6 @@ __author__ = 'Artur Maciag'
 __email__ = 'maciag.artur@gmail.com'
 __version__ = '0.1.5'
 __url__ = 'https://github.com/p1c2u/openapi-schema-validator'
-__license__ = 'BSD 3-Clause License'
+__license__ = '3-clause BSD License'
 
 __all__ = ['validate', 'OAS30Validator', 'oas30_format_checker']


### PR DESCRIPTION
This makes it easier for automatic license checkers to verify the license of this package.