### PR TITLE
Fix DeprecationWarning from jsonschema

### DIFF
--- a/openapi_schema_validator/validators.py
+++ b/openapi_schema_validator/validators.py
@@ -1,3 +1,4 @@
+from attr import attrib, attrs
 from copy import deepcopy
 
 from jsonschema import _legacy_validators, _utils, _validators
@@ -56,12 +57,11 @@ BaseOAS30Validator = create(
 )
 
 
+@attrs
 class OAS30Validator(BaseOAS30Validator):
 
-    def __init__(self, *args, **kwargs):
-        self.read = kwargs.pop('read', None)
-        self.write = kwargs.pop('write', None)
-        super(OAS30Validator, self).__init__(*args, **kwargs)
+    read: bool = attrib(default=None)
+    write: bool = attrib(default=None)
 
     def iter_errors(self, instance, _schema=None):
         if _schema is None:
@@ -74,4 +74,5 @@ class OAS30Validator(BaseOAS30Validator):
                 'nullable': False,
             })
 
-        return super(OAS30Validator, self).evolve(schema=_schema).iter_errors(instance)
+        validator = self.evolve(schema=_schema)
+        return super(OAS30Validator, validator).iter_errors(instance)

--- a/openapi_schema_validator/validators.py
+++ b/openapi_schema_validator/validators.py
@@ -74,4 +74,4 @@ class OAS30Validator(BaseOAS30Validator):
                 'nullable': False,
             })
 
-        return super(OAS30Validator, self).iter_errors(instance, _schema)
+        return super(OAS30Validator, self).evolve(schema=_schema).iter_errors(instance)

--- a/poetry.lock
+++ b/poetry.lock
@@ -8,17 +8,17 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "attrs"
-version = "21.3.0"
+version = "21.4.0"
 description = "Classes Without Boilerplate"
 category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [package.extras]
-dev = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit"]
+dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit", "cloudpickle"]
 docs = ["furo", "sphinx", "zope.interface", "sphinx-notfound-page"]
-tests = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface"]
-tests_no_zope = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins"]
+tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "cloudpickle"]
+tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "cloudpickle"]
 
 [[package]]
 name = "black"
@@ -491,7 +491,7 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "virtualenv"
-version = "20.11.0"
+version = "20.11.1"
 description = "Virtual Python Environment builder"
 category = "dev"
 optional = false
@@ -529,7 +529,7 @@ strict-rfc3339 = ["strict-rfc3339"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6.2"
-content-hash = "7729739041f5306ea7356f29d70dd0b22571fd38fc57f07936a41b124bc26b12"
+content-hash = "70a6d20f9e8b15b8f2c810f32d6973ab9afc13a9a6c9116a321af7d803732dd7"
 
 [metadata.files]
 atomicwrites = [
@@ -537,8 +537,8 @@ atomicwrites = [
     {file = "atomicwrites-1.4.0.tar.gz", hash = "sha256:ae70396ad1a434f9c7046fd2dd196fc04b12f9e91ffb859164193be8b6168a7a"},
 ]
 attrs = [
-    {file = "attrs-21.3.0-py2.py3-none-any.whl", hash = "sha256:8f7335278dedd26b58c38e006338242cc0977f06d51579b2b8b87b9b33bff66c"},
-    {file = "attrs-21.3.0.tar.gz", hash = "sha256:50f3c9b216dc9021042f71b392859a773b904ce1a029077f58f6598272432045"},
+    {file = "attrs-21.4.0-py2.py3-none-any.whl", hash = "sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4"},
+    {file = "attrs-21.4.0.tar.gz", hash = "sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd"},
 ]
 black = [
     {file = "black-21.12b0-py3-none-any.whl", hash = "sha256:a615e69ae185e08fdd73e4715e260e2479c861b5740057fde6e8b4e3b7dd589f"},
@@ -848,8 +848,8 @@ typing-extensions = [
     {file = "typing_extensions-4.0.1.tar.gz", hash = "sha256:4ca091dea149f945ec56afb48dae714f21e8692ef22a395223bcd328961b6a0e"},
 ]
 virtualenv = [
-    {file = "virtualenv-20.11.0-py2.py3-none-any.whl", hash = "sha256:eb0cb34160f32c6596405308ee6a8a4abbf3247b2b9794ae655a156d43abf48e"},
-    {file = "virtualenv-20.11.0.tar.gz", hash = "sha256:2f15b9226cb74b59c21e8236dd791c395bee08cdd33b99cddd18e1f866cdb098"},
+    {file = "virtualenv-20.11.1-py2.py3-none-any.whl", hash = "sha256:43973fb93cf1d04ec00a190f5e062919798a0fec94daaafcb4db1eda1aa8f340"},
+    {file = "virtualenv-20.11.1.tar.gz", hash = "sha256:17f26e9d0c4350d9df713d41077b2b3344cba59e104306e4105c8c75deeddcf7"},
 ]
 zipp = [
     {file = "zipp-3.6.0-py3-none-any.whl", hash = "sha256:9fe5ea21568a0a70e50f273397638d39b03353731e6cbbb3fd8502a33fec40bc"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,10 +33,11 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.6.2"
-jsonschema = "*"
+jsonschema = "^4.0.0"
 rfc3339-validator = {version = "*", optional = true}
 strict-rfc3339 = {version = "*", optional = true}
 isodate = {version = "*", optional = true}
+attrs = ">=19.2.0"
 
 [tool.poetry.extras]
 rfc3339-validator = ["rfc3339-validator"]


### PR DESCRIPTION
```python
        def iter_errors(self, instance, _schema=None):
            if _schema is not None:
                warnings.warn(
                    (
                        "Passing a schema to Validator.iter_errors "
                        "is deprecated and will be removed in a future "
                        "release. Call validator.evolve(schema=new_schema)."
                        "iter_errors(...) instead."
                    ),
                    DeprecationWarning,
                )
```
https://github.com/Julian/jsonschema/blob/main/jsonschema/validators.py#L189-L198