### PR TITLE
Drop no longer used runtime dependency on attrs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,6 @@ jsonschema = "^4.0.0"
 rfc3339-validator = {version = "*", optional = true}
 strict-rfc3339 = {version = "*", optional = true}
 isodate = {version = "*", optional = true}
-attrs = ">=19.2.0"
 
 [tool.poetry.extras]
 rfc3339-validator = ["rfc3339-validator"]


### PR DESCRIPTION
The last usage of attrs has been dropped in 22b12e7, but attrs is still marked as runtime dependency in pyproject.toml.

Fixes: https://github.com/p1c2u/openapi-schema-validator/issues/53