### PR TITLE
fix: typo in docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -150,7 +150,7 @@ You can also check format for primitive types
 References
 **********
 
-You can resolve JOSN references by passing custon reference resolver
+You can resolve JSON references by passing custon reference resolver
 
 .. code-block:: python
 


### PR DESCRIPTION
I just happen to have access to this repository, but I am reporting that I found a typo in the README.